### PR TITLE
feat: Add Ubuntu server dotfiles and install script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# Dotfiles Repository
+
+Personal dotfiles for shell configuration, git settings, and development environment setup.
+
+## Overview
+
+This repository was originally built for macOS with GUI apps. It is being adapted to also support headless Ubuntu servers. The goal is to keep the valuable cross-platform shell and git configurations while removing or gating macOS/GUI-specific parts.
+
+## Repository Structure
+
+```
+.zshrc              # Primary shell config (oh-my-zsh, plugins, aliases, prompt)
+.zprofile           # Zsh login profile (PATH setup, brew env)
+.bash_profile       # Bash login profile (git aliases, navigation aliases)
+.bashrc             # Bash non-login shell (PATH, nvm, git completion)
+.gitconfig          # Git identity, aliases, diff/merge tools, colors
+.git-prompt.sh      # Git branch/status in shell prompt
+.git-completion.bash # Git tab completion for bash
+.hushlogin          # Suppress login banner
+.gitignore          # Global gitignore patterns
+midt.terminal       # macOS Terminal.app theme (macOS-only)
+ubuntu/
+  .zshrc            # Ubuntu-specific zsh config (vim editor, standard NVM paths)
+  .gitconfig        # Ubuntu-specific git config (vim editor, no VS Code)
+  .zprofile         # Minimal Ubuntu PATH setup
+  install.sh        # Ubuntu server install script (apt, oh-my-zsh, plugins, NVM)
+dotfiles/
+  README.md         # Setup documentation
+  apps/Brewfile     # Homebrew package list (macOS-only)
+  configs/marks.json # iTerm2 profile (macOS-only)
+  scripts/
+    bootstrap.sh    # Initial setup - clones bare repo to $HOME/.dotfiles
+    install.sh      # Full install - brew, oh-my-zsh, plugins, macOS defaults
+    macos.sh        # macOS system preferences (100% macOS-only)
+```
+
+## Key Patterns
+
+- **Bare git repo pattern**: Uses `git clone --bare` into `$HOME/.dotfiles` with a `dot` alias so the home directory acts as a git working tree without a `.git` folder. The `dot` command replaces `git` for managing these files.
+- **Oh-My-Zsh**: Primary shell framework with plugins: git, zsh-autosuggestions, zsh-syntax-highlighting, zsh-z.
+- **Pure prompt**: Minimal zsh prompt theme installed to `$HOME/.zsh/pure`.
+- **NVM**: Node version management with auto-switching on `.nvmrc` detection.
+- **Conditional sourcing**: Many integrations use `[[ -f ... ]] && source ...` guards.
+
+## macOS vs Cross-Platform
+
+### macOS-only (irrelevant for Ubuntu server)
+- `macos.sh` - entire file is `defaults write` commands
+- `Brewfile` - Homebrew casks, Mac App Store apps, GUI apps
+- `midt.terminal` - Terminal.app theme
+- `configs/marks.json` - iTerm2 profile
+- `bootstrap.sh` / `install.sh` - both have `uname == Darwin` checks
+- CodeWhisperer/Fig integration blocks in shell configs
+- `osascript` calls, `/opt/homebrew/` paths, `brew shellenv`
+- VS Code as git editor/difftool
+
+### Cross-platform (valuable on Ubuntu)
+- Git aliases and configuration (identity, push behavior, colors, diff-so-fancy)
+- Shell aliases (navigation `..`, `...`, git shortcuts `ga`, `gs`, etc.)
+- Oh-My-Zsh + plugins (autosuggestions, syntax-highlighting, zsh-z)
+- Pure prompt theme
+- NVM setup and `.nvmrc` auto-switching
+- Custom functions (`ghf`, `mk`, `decode`)
+- `.hushlogin`, `.git-prompt.sh`, `.git-completion.bash`
+- GPG setup
+
+## Development Notes
+
+- The install scripts currently reject non-macOS systems (`exit 1` on Linux). Any Ubuntu support needs new or modified scripts.
+- `.gitconfig` has hardcoded macOS paths (`/Users/marks/`) and VS Code as editor. For a server, `vim` or `nano` is more appropriate.
+- `.zprofile` is entirely macOS-specific (Homebrew paths, MacPorts, AVR-GCC).
+- `.zshrc` mixes cross-platform config with macOS-specific integrations (Homebrew completions, `/opt/homebrew/` NVM paths, CodeWhisperer, Fig).
+- `.bash_profile` references `brew --prefix` which won't exist on a standard Ubuntu server.

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -1,8 +1,26 @@
 # Dotfiles
 
-This repository contains my personal dotfiles and setup scripts for macOS.
+This repository contains my personal dotfiles and setup scripts for macOS and Ubuntu servers.
 
-## Quick Start
+## Ubuntu Server Quick Start
+
+To set up a headless Ubuntu server, clone this repo and run the Ubuntu install script:
+
+```bash
+git clone https://github.com/marksdk/dotfiles.git ~/dotfiles-setup
+bash ~/dotfiles-setup/ubuntu/install.sh
+```
+
+This will:
+1. Install essential packages via apt (zsh, git, curl, vim, build-essential, gpg)
+2. Install oh-my-zsh with plugins (autosuggestions, syntax-highlighting, zsh-z)
+3. Install Pure prompt
+4. Install NVM and diff-so-fancy
+5. Set up the bare-repo dotfiles pattern
+6. Copy Ubuntu-specific shell and git configs into place
+7. Change the default shell to zsh
+
+## macOS Quick Start
 
 Run this command to set up a new machine:
 

--- a/ubuntu/.gitconfig
+++ b/ubuntu/.gitconfig
@@ -1,0 +1,47 @@
+[user]
+	name = Mark Hougaard
+	email = mark@hougaard.email
+	signingkey = D42687F214D07A9F
+[color]
+	ui = true
+[github]
+	user = markhougaard
+[push]
+	default = simple
+	followTags = true
+	autoSetupRemote = true
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	required = true
+	process = git-lfs filter-process
+[core]
+	editor = vim
+	pager = diff-so-fancy | less --tabs=4 -RFX
+	excludesfile = ~/.gitignore_global
+[interactive]
+	diffFilter = diff-so-fancy --patch
+[alias]
+	update = !git pull && git submodule update --init --recursive
+	new = !git init && git symbolic-ref HEAD refs/heads/main
+[commit]
+	# gpgsign = true
+[gpg]
+	program = gpg
+[pull]
+	rebase = false
+[init]
+	defaultBranch = main
+[color "diff-highlight"]
+	oldNormal = red bold
+	oldHighlight = red bold 52
+	newNormal = green bold
+	newHighlight = green bold 22
+[color "diff"]
+	meta = 11
+	frag = magenta bold
+	func = 146 bold
+	commit = yellow bold
+	old = red bold
+	new = green bold
+	whitespace = red reverse

--- a/ubuntu/.gitconfig
+++ b/ubuntu/.gitconfig
@@ -4,10 +4,7 @@
 	signingkey = D42687F214D07A9F
 [color]
 	ui = true
-[github]
-	user = markhougaard
 [push]
-	default = simple
 	followTags = true
 	autoSetupRemote = true
 [filter "lfs"]
@@ -18,7 +15,6 @@
 [core]
 	editor = vim
 	pager = diff-so-fancy | less --tabs=4 -RFX
-	excludesfile = ~/.gitignore_global
 [interactive]
 	diffFilter = diff-so-fancy --patch
 [alias]

--- a/ubuntu/.zprofile
+++ b/ubuntu/.zprofile
@@ -1,0 +1,2 @@
+# pyenv
+export PATH="${HOME}/.pyenv/shims:${PATH}"

--- a/ubuntu/.zshrc
+++ b/ubuntu/.zshrc
@@ -1,0 +1,98 @@
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Which plugins would you like to load?
+plugins=(
+  git
+  zsh-autosuggestions
+  zsh-syntax-highlighting
+  zsh-z
+)
+
+ZSH_DISABLE_COMPFIX="true"
+
+source $ZSH/oh-my-zsh.sh
+
+# Editor
+export VISUAL="vim"
+export EDITOR="vim"
+
+# NVM
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+# Calling nvm use automatically in a directory with a .nvmrc file.
+# Source: https://github.com/nvm-sh/nvm#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file
+autoload -U add-zsh-hook
+load-nvmrc() {
+  local node_version="$(nvm version)"
+  local nvmrc_path="$(nvm_find_nvmrc)"
+
+  if [ -n "$nvmrc_path" ]; then
+    local nvmrc_node_version=$(nvm version "$(cat "${nvmrc_path}")")
+
+    if [ "$nvmrc_node_version" = "N/A" ]; then
+      nvm install
+    elif [ "$nvmrc_node_version" != "$node_version" ]; then
+      nvm use
+    fi
+  elif [ "$node_version" != "$(nvm version default)" ]; then
+    echo "Reverting to nvm default version"
+    nvm use default
+  fi
+}
+add-zsh-hook chpwd load-nvmrc
+load-nvmrc
+
+# ghf - [G]rep [H]istory [F]or top ten commands and execute one
+# usage:
+#  Most frequent command in recent history
+#   ghf
+#  Most frequent instances of {command} in all history
+#   ghf {command}
+#  Execute {command-number} after a call to ghf
+#   !! {command-number}
+function latest-history { history | tail -n 50 ; }
+function grepped-history { history | grep "$1" ; }
+function chop-first-column { awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}' ; }
+function add-line-numbers { awk '{print NR " " $0}' ; }
+function top-ten { sort | uniq -c | sort -r | head -n 10 ; }
+function unique-history { chop-first-column | top-ten | chop-first-column | add-line-numbers ; }
+function ghf {
+  if [ $# -eq 0 ]; then latest-history | unique-history; fi
+  if [ $# -eq 1 ]; then grepped-history "$1" | unique-history; fi
+  if [ $# -eq 2 ]; then
+    `grepped-history "$1" | unique-history | grep ^$2 | chop-first-column`;
+  fi
+}
+
+# Add colors to Terminal
+export CLICOLOR=1
+export LSCOLORS=GxFxCxDxBxegedabagaced
+
+# Create a new directory and enter it
+function mk() {
+  mkdir -p "$@" && cd "$@"
+}
+
+# Pure prompt
+fpath+=$HOME/.zsh/pure
+autoload -U promptinit; promptinit
+prompt pure
+
+ZSH_HIGHLIGHT_STYLES[path]=none
+ZSH_HIGHLIGHT_STYLES[path_prefix]=none
+
+# Bare-repo dotfiles management
+alias dot='/usr/bin/git --git-dir=$HOME/.dotfiles/ --work-tree=$HOME'
+
+# Decode base64 strings
+decode () {
+  echo "$1" | base64 -d ; echo
+}
+
+# pyenv
+export PATH="${HOME}/.pyenv/shims:${PATH}"
+
+export GPG_TTY=$(tty)

--- a/ubuntu/.zshrc
+++ b/ubuntu/.zshrc
@@ -67,10 +67,6 @@ function ghf {
   fi
 }
 
-# Add colors to Terminal
-export CLICOLOR=1
-export LSCOLORS=GxFxCxDxBxegedabagaced
-
 # Create a new directory and enter it
 function mk() {
   mkdir -p "$@" && cd "$@"
@@ -91,8 +87,5 @@ alias dot='/usr/bin/git --git-dir=$HOME/.dotfiles/ --work-tree=$HOME'
 decode () {
   echo "$1" | base64 -d ; echo
 }
-
-# pyenv
-export PATH="${HOME}/.pyenv/shims:${PATH}"
 
 export GPG_TTY=$(tty)

--- a/ubuntu/install.sh
+++ b/ubuntu/install.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ubuntu server dotfiles install script
+# Usage: bash ubuntu/install.sh
+
+DOTFILES_REPO="https://github.com/marksdk/dotfiles.git"
+
+# -----------------------------------------------------------
+# 1. Check we're on Linux
+# -----------------------------------------------------------
+if [ "$(uname)" != "Linux" ]; then
+  echo "Error: This script is intended for Linux systems only."
+  exit 1
+fi
+
+echo "==> Starting Ubuntu dotfiles setup..."
+
+# -----------------------------------------------------------
+# 2. Install essential packages via apt
+# -----------------------------------------------------------
+echo "==> Installing essential packages..."
+sudo apt update
+sudo apt install -y \
+  zsh \
+  git \
+  curl \
+  wget \
+  vim \
+  build-essential \
+  gpg
+
+# -----------------------------------------------------------
+# 3. Install oh-my-zsh
+# -----------------------------------------------------------
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  echo "==> Installing oh-my-zsh..."
+  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+else
+  echo "==> oh-my-zsh already installed, skipping."
+fi
+
+# -----------------------------------------------------------
+# 4. Install Pure prompt
+# -----------------------------------------------------------
+if [ ! -d "$HOME/.zsh/pure" ]; then
+  echo "==> Installing Pure prompt..."
+  mkdir -p "$HOME/.zsh"
+  git clone https://github.com/sindresorhus/pure.git "$HOME/.zsh/pure"
+else
+  echo "==> Pure prompt already installed, skipping."
+fi
+
+# -----------------------------------------------------------
+# 5. Install zsh plugins
+# -----------------------------------------------------------
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+
+if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
+  echo "==> Installing zsh-autosuggestions..."
+  git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
+else
+  echo "==> zsh-autosuggestions already installed, skipping."
+fi
+
+if [ ! -d "$ZSH_CUSTOM/plugins/zsh-z" ]; then
+  echo "==> Installing zsh-z..."
+  git clone https://github.com/agkozak/zsh-z "$ZSH_CUSTOM/plugins/zsh-z"
+else
+  echo "==> zsh-z already installed, skipping."
+fi
+
+if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
+  echo "==> Installing zsh-syntax-highlighting..."
+  git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
+else
+  echo "==> zsh-syntax-highlighting already installed, skipping."
+fi
+
+# -----------------------------------------------------------
+# 6. Install NVM
+# -----------------------------------------------------------
+if [ ! -d "$HOME/.nvm" ]; then
+  echo "==> Installing NVM..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+else
+  echo "==> NVM already installed, skipping."
+fi
+
+# -----------------------------------------------------------
+# 7. Install diff-so-fancy
+# -----------------------------------------------------------
+if ! command -v diff-so-fancy &>/dev/null; then
+  echo "==> Installing diff-so-fancy..."
+  # Load NVM so we can use npm
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+  if command -v npm &>/dev/null; then
+    npm install -g diff-so-fancy
+  else
+    echo "  -> Installing Node LTS first..."
+    nvm install --lts
+    npm install -g diff-so-fancy
+  fi
+else
+  echo "==> diff-so-fancy already installed, skipping."
+fi
+
+# -----------------------------------------------------------
+# 8. Set up bare-repo dotfiles
+# -----------------------------------------------------------
+if [ ! -d "$HOME/.dotfiles" ]; then
+  echo "==> Setting up bare-repo dotfiles..."
+  git clone --bare "$DOTFILES_REPO" "$HOME/.dotfiles"
+
+  function dot {
+    /usr/bin/git --git-dir="$HOME/.dotfiles/" --work-tree="$HOME" "$@"
+  }
+
+  # Back up any conflicting files
+  mkdir -p "$HOME/.dotfiles-backup"
+  if ! dot checkout 2>/dev/null; then
+    echo "  -> Backing up pre-existing dotfiles..."
+    dot checkout 2>&1 | grep -E "^\s+" | awk '{print $1}' | xargs -I{} mv "$HOME/{}" "$HOME/.dotfiles-backup/{}"
+    dot checkout
+  fi
+
+  dot config --local status.showUntrackedFiles no
+  echo "  -> Dotfiles checked out successfully."
+else
+  echo "==> Dotfiles bare repo already exists, skipping clone."
+fi
+
+# -----------------------------------------------------------
+# 9. Copy Ubuntu-specific configs into place
+# -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Copying Ubuntu-specific configs..."
+cp "$SCRIPT_DIR/.zshrc" "$HOME/.zshrc"
+cp "$SCRIPT_DIR/.gitconfig" "$HOME/.gitconfig"
+cp "$SCRIPT_DIR/.zprofile" "$HOME/.zprofile"
+
+# -----------------------------------------------------------
+# 10. Change default shell to zsh
+# -----------------------------------------------------------
+if [ "$SHELL" != "$(command -v zsh)" ]; then
+  echo "==> Changing default shell to zsh..."
+  chsh -s "$(command -v zsh)"
+else
+  echo "==> Default shell is already zsh."
+fi
+
+# -----------------------------------------------------------
+# Done
+# -----------------------------------------------------------
+echo ""
+echo "==> Setup complete!"
+echo "    - Log out and back in (or run 'zsh') to start using your new shell."
+echo "    - Your old dotfiles (if any) were backed up to ~/.dotfiles-backup/"

--- a/ubuntu/install.sh
+++ b/ubuntu/install.sh
@@ -19,17 +19,21 @@ echo "==> Starting Ubuntu dotfiles setup..."
 # -----------------------------------------------------------
 # 2. Install essential packages via apt
 # -----------------------------------------------------------
-echo "==> Installing essential packages..."
-sudo apt update
-sudo apt install -y \
-  zsh \
-  git \
-  curl \
-  wget \
-  vim \
-  build-essential \
-  gpg \
-  git-lfs
+if [ "${SKIP_APT:-}" != "1" ]; then
+  echo "==> Installing essential packages..."
+  sudo apt update
+  sudo apt install -y \
+    zsh \
+    git \
+    curl \
+    wget \
+    vim \
+    build-essential \
+    gpg \
+    git-lfs
+else
+  echo "==> Skipping apt install (SKIP_APT=1)."
+fi
 
 # -----------------------------------------------------------
 # 3. Install oh-my-zsh

--- a/ubuntu/install.sh
+++ b/ubuntu/install.sh
@@ -28,7 +28,8 @@ sudo apt install -y \
   wget \
   vim \
   build-essential \
-  gpg
+  gpg \
+  git-lfs
 
 # -----------------------------------------------------------
 # 3. Install oh-my-zsh


### PR DESCRIPTION
## Summary

Adds an `ubuntu/` directory with configs and an install script for headless Ubuntu servers, alongside the existing macOS setup.

### New files
- **`ubuntu/.zshrc`** — Clean zsh config with `vim` as editor, standard `$HOME/.nvm` paths, oh-my-zsh + plugins (git, autosuggestions, syntax-highlighting, zsh-z), Pure prompt, custom functions (`ghf`, `mk`, `decode`), `dot` alias, GPG
- **`ubuntu/.gitconfig`** — Git config with `vim` editor, diff-so-fancy pager, git-lfs, shared aliases and diff colors. No VS Code, no macOS paths
- **`ubuntu/.zprofile`** — Minimal login profile (pyenv shims PATH)
- **`ubuntu/install.sh`** — Full idempotent install script: apt packages, oh-my-zsh, zsh plugins, Pure prompt, NVM, diff-so-fancy, bare-repo dotfiles setup, default shell change. Supports `SKIP_APT=1` to skip the sudo apt step

### Updated files
- **`CLAUDE.md`** — Added `ubuntu/` to repository structure
- **`dotfiles/README.md`** — Added Ubuntu Server Quick Start section

### Usage

```bash
# Full install (will prompt for sudo password):
bash ubuntu/install.sh

# If packages are already installed:
SKIP_APT=1 bash ubuntu/install.sh
```

## Test plan

- [ ] Run `bash ubuntu/install.sh` on a fresh Ubuntu server
- [ ] Verify zsh starts with Pure prompt, plugins, and correct editor (`vim`)
- [ ] Verify `dot` alias works for bare-repo management
- [ ] Verify `git` uses vim as editor and diff-so-fancy as pager
- [ ] Verify NVM loads and `.nvmrc` auto-switching works
- [ ] Verify custom functions (`ghf`, `mk`, `decode`) are available
- [ ] Re-run install script to confirm idempotency (no errors on second run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)